### PR TITLE
fix tokeninfo in setAuthenticationContext

### DIFF
--- a/src/main/java/org/nmfw/foodietree/domain/auth/security/filter/AuthJwtFilter.java
+++ b/src/main/java/org/nmfw/foodietree/domain/auth/security/filter/AuthJwtFilter.java
@@ -53,6 +53,7 @@ public class AuthJwtFilter extends OncePerRequestFilter {
                         try {
                             TokenUserInfo refreshTokenInfo = tokenProvider.validateAndGetRefreshTokenInfo(refreshToken);
                             handleRefreshToken(request, response, refreshTokenInfo);
+                            setAuthenticationContext(request, refreshTokenInfo);
                             log.info("refresh token 기간 안 ✅");
                         } catch (JwtException ex) {
                             log.error("Refresh token parsing error: {}", ex.getMessage());


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
리프레쉬토큰 사용시, AuthenticationPrincipal TokenUserInfo userInfo 에 null 발생
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업사항
- 리프레쉬 토큰 사용시 setAuthenticationContext 에 tokenInfo 설정

## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
