### PR TITLE
# Fix/header에 새로운 refreshtoken을 응답하지 않았음

### DIFF
--- a/src/main/java/org/nmfw/foodietree/domain/auth/security/filter/AuthJwtFilter.java
+++ b/src/main/java/org/nmfw/foodietree/domain/auth/security/filter/AuthJwtFilter.java
@@ -90,7 +90,8 @@ public class AuthJwtFilter extends OncePerRequestFilter {
 
             // 로그인 함과 동시에 토큰, 리프레시 토큰 재발급
             String token = tokenProvider.createToken(email, userType);
-            userService.setUserRefreshTokenExpiryDate(email, userType);
+            String refreshToken = tokenProvider.createRefreshToken(email, userType);
+            userService.setUserRefreshTokenExpiryDate(refreshToken ,email, userType);
 
             log.info("리프레시 토큰 및 액세스 토큰 재발급 ✅");
 
@@ -103,6 +104,7 @@ public class AuthJwtFilter extends OncePerRequestFilter {
 
             // Set new tokens in response headers
             response.setHeader("token", token);
+            response.setHeader("refreshToken", refreshToken);
             return;
         }
 

--- a/src/main/java/org/nmfw/foodietree/domain/auth/service/UserService.java
+++ b/src/main/java/org/nmfw/foodietree/domain/auth/service/UserService.java
@@ -166,10 +166,10 @@ public class UserService {
         }
     }
 
-    public void setUserRefreshTokenExpiryDate(String email, String userType) {
+    public void setUserRefreshTokenExpiryDate(String refreshToken, String email,String userType) {
 
-        String newRefreshToken = tokenProvider.createRefreshToken(email, userType);
-        LocalDateTime newExpiryDate = tokenProvider.getExpirationDateFromRefreshToken(newRefreshToken);
+
+        LocalDateTime newExpiryDate = tokenProvider.getExpirationDateFromRefreshToken(refreshToken);
 
         if ("customer".equals(userType)) {
             Customer customer = customerService.getCustomerById(email);


### PR DESCRIPTION
- header refresh token 과 실제 새로 발급받은 refreshtoken 이 달라서 userInfo 에서 token정보를 찾아오지 못하는 문제

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 새로 발급받은 refreshtoken을 발급받았으나 header에 저장하지 않음
-- 이로인한 header 의 토큰정보와 server 측의 토큰정보가 달라 -> 유효성 검증 실패 -> userInfo 객체자체가 null 이 되는 버그 픽스

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업사항
-

## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
