### PR TITLE
fix 가게 상품 수량을 조회 시 발생하는 문제

### DIFF
--- a/src/main/java/org/nmfw/foodietree/domain/customer/repository/FavStoreRepositoryCustomImpl.java
+++ b/src/main/java/org/nmfw/foodietree/domain/customer/repository/FavStoreRepositoryCustomImpl.java
@@ -60,6 +60,7 @@ public class FavStoreRepositoryCustomImpl implements FavStoreRepositoryCustom {
                 .from(store)
                 .leftJoin(product).on(s.storeId.eq(p.storeId))
                 .leftJoin(reservation).on(p.productId.eq(r.productId))
+                .where(r.rowNum.eq(1L))
                 .groupBy(s.storeId)
                 .having(s.storeId.in(inTarget))
                 .fetch()

--- a/src/main/java/org/nmfw/foodietree/domain/customer/repository/FavStoreRepositoryCustomImpl.java
+++ b/src/main/java/org/nmfw/foodietree/domain/customer/repository/FavStoreRepositoryCustomImpl.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.nmfw.foodietree.domain.product.entity.QProduct;
 import org.nmfw.foodietree.domain.reservation.entity.QReservation;
+import org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect;
 import org.nmfw.foodietree.domain.store.dto.resp.StoreListDto;
 import org.nmfw.foodietree.domain.store.entity.QStore;
 import org.nmfw.foodietree.global.utils.QueryDslUtils;
@@ -24,6 +25,7 @@ import static com.querydsl.jpa.JPAExpressions.select;
 import static org.nmfw.foodietree.domain.customer.entity.QFavStore.favStore;
 import static org.nmfw.foodietree.domain.product.entity.QProduct.product;
 import static org.nmfw.foodietree.domain.reservation.entity.QReservation.reservation;
+import static org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect.reservationSubSelect;
 import static org.nmfw.foodietree.domain.store.entity.QStore.store;
 
 @Repository
@@ -34,7 +36,7 @@ public class FavStoreRepositoryCustomImpl implements FavStoreRepositoryCustom {
 
     @Override
     public List<StoreListDto> findFavStoresByCustomerId(String customerId, String type) {
-        QReservation r = reservation;
+        QReservationSubSelect r = reservationSubSelect;
         QProduct p = product;
         QStore s = store;
         JPQLQuery<String> inTarget = null;
@@ -46,9 +48,9 @@ public class FavStoreRepositoryCustomImpl implements FavStoreRepositoryCustom {
                     .where(favStore.customerId.eq(customerId));
         } else if (type.equals("orders_3")) {
             inTarget = select(product.storeId)
-                    .from(reservation)
-                    .innerJoin(product).on(reservation.productId.eq(product.productId))
-                    .where(reservation.customerId.eq(customerId).and(reservation.pickedUpAt.isNotNull()))
+                    .from(reservationSubSelect)
+                    .innerJoin(product).on(r.productId.eq(product.productId))
+                    .where(r.customerId.eq(customerId).and(r.pickedUpAt.isNotNull()))
                     .groupBy(product.storeId)
                     .having(product.storeId.count().goe(3));
         }
@@ -59,8 +61,8 @@ public class FavStoreRepositoryCustomImpl implements FavStoreRepositoryCustom {
                 .select(store, cnt)
                 .from(store)
                 .leftJoin(product).on(s.storeId.eq(p.storeId))
-                .leftJoin(reservation).on(p.productId.eq(r.productId))
-                .where(r.rowNum.eq(1L))
+                .leftJoin(reservationSubSelect).on(p.productId.eq(r.productId))
+                .where(r.rowNum.isNull().or(r.rowNum.eq(1L)))
                 .groupBy(s.storeId)
                 .having(s.storeId.in(inTarget))
                 .fetch()

--- a/src/main/java/org/nmfw/foodietree/domain/reservation/entity/Reservation.java
+++ b/src/main/java/org/nmfw/foodietree/domain/reservation/entity/Reservation.java
@@ -5,6 +5,14 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import org.hibernate.annotations.Subselect;
+
+@Subselect(
+    "select "
+	+ "    r.*, "
+	+ "    ROW_NUMBER() over (PARTITION BY r.product_id order by r.reservation_time desc) as row_num "
+	+ "from tbl_reservation r"
+)
 
 @Entity
 @Table(name = "tbl_reservation")
@@ -49,4 +57,7 @@ public class Reservation {
     @Setter
     @Column(name = "cancel_payment_at")
     private LocalDateTime cancelPaymentAt;
+
+	@Column(name = "row_num")
+	private Long rowNum;
 }

--- a/src/main/java/org/nmfw/foodietree/domain/reservation/entity/ReservationSubSelect.java
+++ b/src/main/java/org/nmfw/foodietree/domain/reservation/entity/ReservationSubSelect.java
@@ -1,20 +1,28 @@
 package org.nmfw.foodietree.domain.reservation.entity;
 
-import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-
-import javax.persistence.*;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.Subselect;
+import org.hibernate.annotations.Synchronize;
+
+@Subselect(
+    "select "
+	+ "    r.*, "
+	+ "    ROW_NUMBER() over (PARTITION BY r.product_id order by r.reservation_time desc) as row_num "
+	+ "from tbl_reservation r"
+)
 
 @Entity
-@Table(name = "tbl_reservation")
-@Getter
-@ToString
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class Reservation {
+@Immutable
+@Synchronize("tbl_reservation")
+public class ReservationSubSelect {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,4 +59,6 @@ public class Reservation {
     @Column(name = "cancel_payment_at")
     private LocalDateTime cancelPaymentAt;
 
+	@Column(name = "row_num")
+	private Long rowNum;
 }

--- a/src/main/java/org/nmfw/foodietree/domain/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/org/nmfw/foodietree/domain/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -135,7 +135,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
             .and(p.pickupTime.gt(LocalDateTime.now()))
             .and(r.reservationTime.isNull()
 				.or(
-					r.paymentId.isNull()
+					r.paymentTime.isNull()
 						.and(r.reservationTime.lt(LocalDateTime.now().minusMinutes(5)))
 				)
 			);
@@ -147,7 +147,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                         product.productId))
                 .from(product)
                 .leftJoin(reservation).on(p.productId.eq(r.productId))
-                .where(condition)
+                .where(condition.and(reservation.rowNum.eq(1L)))
                 .limit(cnt)
                 .fetch();
     }

--- a/src/main/java/org/nmfw/foodietree/domain/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/org/nmfw/foodietree/domain/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -13,6 +13,7 @@ import org.nmfw.foodietree.domain.reservation.dto.resp.ReservationDetailDto;
 import org.nmfw.foodietree.domain.reservation.dto.resp.ReservationFoundStoreIdDto;
 import org.nmfw.foodietree.domain.reservation.dto.resp.ReservationStatusDto;
 import org.nmfw.foodietree.domain.reservation.entity.QReservation;
+import org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect;
 import org.nmfw.foodietree.domain.store.dto.resp.StoreReservationDto;
 import org.nmfw.foodietree.domain.store.entity.QStore;
 import org.springframework.stereotype.Repository;
@@ -24,6 +25,7 @@ import java.util.List;
 import static org.nmfw.foodietree.domain.customer.entity.QCustomer.customer;
 import static org.nmfw.foodietree.domain.product.entity.QProduct.product;
 import static org.nmfw.foodietree.domain.reservation.entity.QReservation.reservation;
+import static org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect.reservationSubSelect;
 import static org.nmfw.foodietree.domain.store.entity.QStore.store;
 
 @Repository
@@ -128,7 +130,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
     // 예약 가능 제품 조회
     @Override
     public List<ReservationFoundStoreIdDto> findByStoreIdLimit(String storeId, int cnt) {
-        QReservation r = reservation;
+        QReservationSubSelect r = reservationSubSelect;
         QProduct p = product;
 
         BooleanExpression condition = p.storeId.eq(storeId)
@@ -146,8 +148,8 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                         product.storeId,
                         product.productId))
                 .from(product)
-                .leftJoin(reservation).on(p.productId.eq(r.productId))
-                .where(condition.and(reservation.rowNum.eq(1L)))
+                .leftJoin(reservationSubSelect).on(p.productId.eq(r.productId))
+                .where(condition.and(r.rowNum.isNull().or(r.rowNum.eq(1L))))
                 .limit(cnt)
                 .fetch();
     }

--- a/src/main/java/org/nmfw/foodietree/domain/store/repository/SearchRepositoryCustomImpl.java
+++ b/src/main/java/org/nmfw/foodietree/domain/store/repository/SearchRepositoryCustomImpl.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nmfw.foodietree.domain.product.entity.QProduct;
 import org.nmfw.foodietree.domain.reservation.entity.QReservation;
+import org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect;
 import org.nmfw.foodietree.domain.store.dto.resp.SearchedStoreListDto;
 import org.nmfw.foodietree.domain.store.entity.QStore;
 import org.nmfw.foodietree.domain.store.entity.Store;
@@ -25,7 +26,7 @@ import java.util.stream.Collectors;
 
 import static com.querydsl.jpa.JPAExpressions.select;
 import static org.nmfw.foodietree.domain.product.entity.QProduct.product;
-import static org.nmfw.foodietree.domain.reservation.entity.QReservation.reservation;
+import static org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect.reservationSubSelect;
 import static org.nmfw.foodietree.domain.store.entity.QStore.store;
 
 @Repository
@@ -36,7 +37,7 @@ public class SearchRepositoryCustomImpl implements SearchRepositoryCustom {
 
     @Override
     public Page<SearchedStoreListDto> findStores(Pageable pageable, String keyword) {
-        QReservation r = reservation;
+        QReservationSubSelect r = reservationSubSelect;
         QProduct p = product;
         QStore s = store;
         Expression<Integer> cnt = QueryDslUtils.getCurrProductCntExpression(p, r);
@@ -46,8 +47,8 @@ public class SearchRepositoryCustomImpl implements SearchRepositoryCustom {
                 .select(store, cnt)
                 .from(store)
                 .leftJoin(product).on(s.storeId.eq(p.storeId))
-                .leftJoin(reservation).on(p.productId.eq(r.productId))
-                .where(expression.and(r.rowNum.eq(1L)))
+                .leftJoin(reservationSubSelect).on(p.productId.eq(r.productId))
+                .where(expression.and(r.rowNum.isNull().or(r.rowNum.eq(1L))))
                 .groupBy(s.storeId)
                 .having(store.isNotNull())
                 .offset(pageable.getOffset())
@@ -60,7 +61,7 @@ public class SearchRepositoryCustomImpl implements SearchRepositoryCustom {
                 .select(store)
                 .from(store)
                 .leftJoin(product).on(s.storeId.eq(p.storeId))
-                .leftJoin(reservation).on(p.productId.eq(r.productId))
+                .leftJoin(reservationSubSelect).on(p.productId.eq(r.productId))
                 .where(expression)
                 .groupBy(s.storeId)
                 .having(store.isNotNull())

--- a/src/main/java/org/nmfw/foodietree/domain/store/repository/SearchRepositoryCustomImpl.java
+++ b/src/main/java/org/nmfw/foodietree/domain/store/repository/SearchRepositoryCustomImpl.java
@@ -47,7 +47,7 @@ public class SearchRepositoryCustomImpl implements SearchRepositoryCustom {
                 .from(store)
                 .leftJoin(product).on(s.storeId.eq(p.storeId))
                 .leftJoin(reservation).on(p.productId.eq(r.productId))
-                .where(expression)
+                .where(expression.and(r.rowNum.eq(1L)))
                 .groupBy(s.storeId)
                 .having(store.isNotNull())
                 .offset(pageable.getOffset())

--- a/src/main/java/org/nmfw/foodietree/domain/store/repository/StoreListRepositoryCustomImpl.java
+++ b/src/main/java/org/nmfw/foodietree/domain/store/repository/StoreListRepositoryCustomImpl.java
@@ -18,6 +18,7 @@ import org.nmfw.foodietree.domain.customer.dto.resp.UpdateAreaDto;
 import org.nmfw.foodietree.domain.product.entity.Product;
 import org.nmfw.foodietree.domain.product.entity.QProduct;
 import org.nmfw.foodietree.domain.reservation.entity.QReservation;
+import org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect;
 import org.nmfw.foodietree.domain.store.dto.resp.StoreListByEndTimeDto;
 import org.nmfw.foodietree.domain.store.dto.resp.StoreListCo2Dto;
 import org.nmfw.foodietree.domain.store.dto.resp.StoreListDto;
@@ -33,7 +34,7 @@ import java.util.stream.Collectors;
 
 import static com.querydsl.core.group.GroupBy.groupBy;
 import static org.nmfw.foodietree.domain.product.entity.QProduct.product;
-import static org.nmfw.foodietree.domain.reservation.entity.QReservation.reservation;
+import static org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect.reservationSubSelect;
 import static org.nmfw.foodietree.domain.store.entity.QStore.store;
 
 @Repository
@@ -86,7 +87,7 @@ public class StoreListRepositoryCustomImpl implements StoreListRepositoryCustom 
 
     @Override
     public List<StoreListDto> findAllProductsStoreId() {
-        QReservation r = reservation;
+        QReservationSubSelect r = reservationSubSelect;
         QProduct p = product;
         QStore s = store;
 
@@ -96,7 +97,7 @@ public class StoreListRepositoryCustomImpl implements StoreListRepositoryCustom 
                 .select(store, cnt)
                 .from(store)
                 .leftJoin(product).on(s.storeId.eq(p.storeId))
-                .leftJoin(reservation).on(p.productId.eq(r.productId))
+                .leftJoin(reservationSubSelect).on(p.productId.eq(r.productId))
                 .groupBy(s.storeId)
                 .having(store.isNotNull())
                 .fetch()

--- a/src/main/java/org/nmfw/foodietree/global/utils/QueryDslUtils.java
+++ b/src/main/java/org/nmfw/foodietree/global/utils/QueryDslUtils.java
@@ -8,10 +8,11 @@ import org.nmfw.foodietree.domain.product.entity.QProduct;
 import org.nmfw.foodietree.domain.reservation.entity.QReservation;
 
 import java.time.LocalDateTime;
+import org.nmfw.foodietree.domain.reservation.entity.QReservationSubSelect;
 
 public class QueryDslUtils {
 
-    public static Expression<Integer> getCurrProductCntExpression(QProduct p, QReservation r) {
+    public static Expression<Integer> getCurrProductCntExpression(QProduct p, QReservationSubSelect r) {
         NumberExpression<Integer> currProductCnt = new CaseBuilder()
                 .when(p.pickupTime.gt(LocalDateTime.now())
                         .and(r.reservationTime.isNull()

--- a/src/main/java/org/nmfw/foodietree/global/utils/QueryDslUtils.java
+++ b/src/main/java/org/nmfw/foodietree/global/utils/QueryDslUtils.java
@@ -15,7 +15,7 @@ public class QueryDslUtils {
         NumberExpression<Integer> currProductCnt = new CaseBuilder()
                 .when(p.pickupTime.gt(LocalDateTime.now())
                         .and(r.reservationTime.isNull()
-                                .or(r.paymentId.isNull().and(r.reservationTime.lt(LocalDateTime.now().minusMinutes(5))))
+                                .or(r.paymentTime.isNull().and(r.reservationTime.lt(LocalDateTime.now().minusMinutes(5))))
                         ))
                 .then(1)
                 .otherwise(0)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
수량 조회 시 발생하는 문제
-> 동일한 상품아이디에 대한 다수의 예약이 있을 수 있음(중복 제거하기)
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 작업사항
- 동일한 productId에 대한 다수의 예약들을 처리하기 위한 조건 보완
- reservation entity에 Subquery 애노테이션 추가
- 윈도우 함수 ROW_NUM()을 이용
- 동일한 상품아이디를 갖는 레코드들에 대해서 reservation_time 내림차순으로 정렬
- row_num = 1 조건 부여
- Synchronize 애노테이션을 활용해 view 사용
- https://stackoverflow.com/questions/25226244/what-is-the-use-of-synchronize-in-hibernate


## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
